### PR TITLE
Improve Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ WORKDIR /app
 
 # install dependencies
 COPY poetry.lock pyproject.toml ./
-RUN poetry install
+RUN poetry install --only main
 
 # add project files *after* dependencies
 # https://docs.docker.com/build/building/cache/#order-your-layers


### PR DESCRIPTION
Add `--env-file .env` flag to `uvicorn` command examples in README, so new developers will see an easy cross-platform way to "import" environment variables from .env file.

Add python-dotenv to pyproject.toml as "dev" dependency, because it's required for the `--env-file` feature of uvicorn; update poetry.lock.

Update Dockerfile (EU-82) to have poetry installing only "main" dependencies and therefore reduce docker image size.